### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: Run Tests
 
+permissions:
+  contents: read
+  statuses: write
+  id-token: write
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/tobrien/minorprompt/security/code-scanning/1](https://github.com/tobrien/minorprompt/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimum permissions required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for basic repository access.
- `statuses: write` is required to update commit statuses.
- `id-token: write` may be required for the `codecov/codecov-action@v5` to authenticate securely.

The `permissions` block will be added at the top level of the workflow, applying to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
